### PR TITLE
updated to v3.1.0, updated geocoder.db to use 2021 TIGER/Line Shapefi…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:20.04
 
 # DeGAUSS container metadata
 ENV degauss_name="geocoder"
-ENV degauss_version="3.0.2"
+ENV degauss_version="3.1.0"
 ENV degauss_description="geocode"
 ENV degauss_argument="valid_geocode_score_threshold [default: 0.5]"
 
@@ -12,8 +12,8 @@ LABEL "org.degauss.version"="${degauss_version}"
 LABEL "org.degauss.description"="${degauss_description}"
 LABEL "org.degauss.argument"="${degauss_argument}"
 
-ADD https://geomarker.s3.us-east-2.amazonaws.com/geocoder_2019.db /opt/geocoder.db
-# COPY geocoder_2019.db /opt/geocoder.db
+ADD https://geocoder-2021.s3.amazonaws.com/geocoder.db /opt/geocoder.db
+# COPY geocoder.db /opt/geocoder.db
 
 RUN apt-get update && apt-get install -y \
     libssl-dev \

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 Note that you can call an older version of the geocoder by specifying its version number in the docker ![tag](https://hub.docker.com/repository/docker/degauss/geocoder/tags?page=1&ordering=last_updated)
 
+### Version 3.1
+
+- the geocoder now uses **2021** TIGER/Line address range files
+
 ### Version 3.0
 
 - the geocoder now uses **2019** TIGER/Line address range files


### PR DESCRIPTION
geocode.db updated with 2021 TIGER files. Tested by successfully building Docker image and geocoding test files. Currently self hosting geocode.db on S3 bucket but might need to migrate off self hosting depending on utilization. Will try to update instructions on how to update geocode.db for future releases. 